### PR TITLE
feat(main.rs): append/use plugin name rather than package filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can find examples in this repo and in https://github.com/fermyon/spin-trigge
 When you have a new build of your plugin ready:
 
 * Run `spin pluginify`
-  * It should create or update a `.tar.gz` file and a `<PLUGIN-NAME>.json` manifest
+  * It should create or update a `<PLUGIN-NAME>.tar.gz` file and a `<PLUGIN-NAME>.json` manifest
 * Run `spin plugins install --file <PLUGIN-NAME>.json --yes`
 
 If you want to save keystrokes, you can use `spin pluginify --install` to do both steps at once.

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,8 +219,18 @@ impl PluginifyCommand {
             eprintln!("About to create tar archive at {}", tar_path.display());
         }
 
+        // Use the plugin name for appending to the tar archive
+        // Determine if an extension is needed per the package executable
+        let name = match package.extension() {
+            Some(ext) => match ext.to_str() {
+                Some(ext) => ps.name.clone() + "." + ext,
+                None => ps.name.clone()
+            },
+            None => ps.name.clone()
+        };
+
         if self.verbose {
-            eprintln!("Appending {} with name {:?}", package.display(), ps.name);
+            eprintln!("Appending {} with name {:?}", package.display(), name);
         }
 
         let mut writer = std::fs::File::create(&tar_path)?;
@@ -228,7 +238,7 @@ impl PluginifyCommand {
             let mut enc = GzEncoder::new(&writer, Compression::default());
             {
                 let mut tar_builder = tar::Builder::new(&mut enc);
-                tar_builder.append_path_with_name(&package, &ps.name)?;
+                tar_builder.append_path_with_name(&package, &name)?;
                 tar_builder.finish()?;
             }
             enc.flush()?;
@@ -236,7 +246,7 @@ impl PluginifyCommand {
         writer.flush()?;
 
         if self.verbose {
-            eprintln!("Appended {} with name {:?}", package.display(), ps.name);
+            eprintln!("Appended {} with name {:?}", package.display(), name);
         }
 
         Ok(tar_path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,14 +214,13 @@ impl PluginifyCommand {
             eprintln!("...package exists = {}", package.exists());
         }
 
-        let filename = package.file_name().ok_or_else(|| anyhow!("Can't get filename of {}", package.display()))?;
         let tar_path = PathBuf::from(format!("{}-{}-{}-{}.tar.gz", ps.name, ps.version, os, arch)).absolutize()?.to_path_buf();
         if self.verbose {
             eprintln!("About to create tar archive at {}", tar_path.display());
         }
 
         if self.verbose {
-            eprintln!("Appending {} with name {:?}", package.display(), filename);
+            eprintln!("Appending {} with name {:?}", package.display(), ps.name);
         }
 
         let mut writer = std::fs::File::create(&tar_path)?;
@@ -229,7 +228,7 @@ impl PluginifyCommand {
             let mut enc = GzEncoder::new(&writer, Compression::default());
             {
                 let mut tar_builder = tar::Builder::new(&mut enc);
-                tar_builder.append_path_with_name(&package, filename)?;
+                tar_builder.append_path_with_name(&package, &ps.name)?;
                 tar_builder.finish()?;
             }
             enc.flush()?;
@@ -237,7 +236,7 @@ impl PluginifyCommand {
         writer.flush()?;
 
         if self.verbose {
-            eprintln!("Appended {} with name {:?}", package.display(), filename);
+            eprintln!("Appended {} with name {:?}", package.display(), ps.name);
         }
 
         Ok(tar_path)


### PR DESCRIPTION
This allows for an arbitrary package/executable name but ensures the plugin is invoked by its assigned name via spin.

This won't change the behavior when the plugin name and package filename are the same, which might usually be the case, but supports use cases where the filename may differ per the plugin developer's use case.  For example a `foo` plugin whose package filename is `foo-plugin`:

```toml
name = "foo"
version = "0.1"
spin_compatibility = ">=0.7"
license = "Apache-2.0"
package = "./target/release/foo-plugin"
```

Regardless of the package filename, the plugin will be invoked via its given name, here `"foo"`, eg `spin foo bar`.