### PR TITLE
feat(main.rs): add error when unable to read settings file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,10 @@ fn main() -> Result<(), Error> {
 impl PluginifyCommand {
     fn run_local(&self) -> Result<(), Error> {
         let file = self.file.clone().unwrap_or_else(|| PathBuf::from("spin-pluginify.toml"));
-        let text = std::fs::read_to_string(&file)?;
+        let text = match std::fs::read_to_string(&file) {
+            Ok(file) => file,
+            Err(error) => anyhow::bail!("Cannot read settings file {}: {}", file.display(), error),
+        };
 
         let ps: PackagingSettings = toml::from_str(&text)?;
 


### PR DESCRIPTION
I was stumped by the following output for an embarrassing amount of time:

```
$ spin pluginify
Warning: You're using a pre-release version of Spin (1.5.0-pre0). This plugin might not be compatible (supported: >=0.7). Continuing anyway.
Error: No such file or directory (os error 2)
```

The culprit was I hadn't yet created the settings file, so thought to wrap the error with a bit more context to help future users.