### PR TITLE
allow pluginify to work when cross-compiling for windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,12 +264,6 @@ struct MergeFiles {
     tar: PathBuf,
 }
 
-#[cfg(not(target_os = "windows"))]
-fn infer_package_path(ps: &PackagingSettings) -> PathBuf {
-    ps.package.clone()
-}
-
-#[cfg(target_os = "windows")]
 fn infer_package_path(ps: &PackagingSettings) -> PathBuf {
     let mut package = ps.package.clone();
     {


### PR DESCRIPTION
Spin message trigger can't compile on windows at the moment due to some issues with sqllite3-parser. Attempting to cross-compile fails because the package can't be detected - this would fix that.