### PR TITLE
allow adding directories to assets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,12 @@ impl PluginifyCommand {
                 let mut tar_builder = tar::Builder::new(&mut enc);
                 tar_builder.append_path_with_name(&package, &name)?;
                 for asset in ps.assets() {
-                    tar_builder.append_path(asset).with_context(|| format!("Adding {}", asset.display()))?;
+                    if asset.is_dir() {
+                        tar_builder.append_dir_all(asset, asset)
+                        .with_context(|| format!("Adding {}", asset.display()))?;
+                    } else {
+                        tar_builder.append_path(asset).with_context(|| format!("Adding {}", asset.display()))?;
+                    }
                 }
                 tar_builder.finish()?;
             }


### PR DESCRIPTION
This allows directories to be added to the assets list which should simplify plugins that require access to multiple files. 