### PR TITLE
Always uninstall before installing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ impl PluginifyCommand {
         }
 
         if self.install {
-            spin::plugin_install_file(manifest_path)?;
+            spin::plugin_install_file(&manifest.name, manifest_path)?;
         }
 
         Ok(())

--- a/src/spin.rs
+++ b/src/spin.rs
@@ -1,10 +1,21 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-pub fn plugin_install_file(file: PathBuf) -> Result<(), std::io::Error> {
+pub fn plugin_install_file(name: &str, file: PathBuf) -> Result<(), std::io::Error> {
     let spin = std::env::var("SPIN_BIN_PATH").unwrap_or("spin".into());
 
-    Command::new(spin)
+    let uninstall_result = Command::new(&spin)
+        .arg("plugin")
+        .arg("uninstall")
+        .arg(name)
+        .spawn()?
+        .wait();
+
+    if is_fail(&uninstall_result) {
+        eprintln!("Failed to uninstall old plugin - continuing");
+    }
+
+    Command::new(&spin)
         .arg("plugin")
         .arg("install")
         .arg("--file")
@@ -14,4 +25,11 @@ pub fn plugin_install_file(file: PathBuf) -> Result<(), std::io::Error> {
         .wait()?;
 
     Ok(())
+}
+
+fn is_fail(res: &std::io::Result<std::process::ExitStatus>) -> bool {
+    match res {
+        Err(_) => true,
+        Ok(st) => st.code() != Some(0),
+    }
 }


### PR DESCRIPTION
Because `spin plugins install` has opinions about the direction of update-installs and I refute, reject, and rebut its opinions.
