### PR TITLE
fix(build.yaml): bump rust to 1.81

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.66
+          toolchain: 1.81
           targets: ${{ matrix.config.target }}
       - name: Set up for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
Sorry, a follow-up to https://github.com/itowlson/spin-pluginify/pull/20, wherein the Cargo.lock version was bumped to v4, which [isn't supported by the older 1.66 rust version](https://github.com/itowlson/spin-pluginify/actions/runs/16947844246/job/48033213371) that was set previously in build.yaml

This fix bumps the Rust version to 1.81 in the build.yaml, chosen as it is the minimum supported version for the current vergen library version (again added in #20), but happy to revise approach if we'd prefer not to require this version.